### PR TITLE
Clean up poc implementation

### DIFF
--- a/supa_audit--0.1.0.sql
+++ b/supa_audit--0.1.0.sql
@@ -10,24 +10,57 @@
         Generic audit history for tables including an indentifier
         to enable indexed linear time lookup of a primary key's version history
 */
+
+
 -- Namespace to "audit"
 create schema if not exists audit;
 
--- Create enum type for SQL operations to reduce disk/memory usage vs text
-create type audit.operation as enum ('INSERT', 'UPDATE', 'DELETE', 'TRUNCATE');
 
--- Table for tracking version history for records
-create table audit.record_version_history(
-    id             bigserial primary key, -- unique auto-incrementing id
-    record_id      uuid,                  -- uniquely identifies a record by primary key [primary key + table_oid]
-    old_record_id  uuid,                  -- uniquely identifies identity of record before update/delete before an update
-    op             audit.operation,       -- INSERT/UPDATE/DELETE/TRUNCATE
-    ts             timestamp default (now() at time zone 'utc'),
-    entity_oid     int,                   -- uid of table, robust to drop and re-create
-    record         json                   -- contents of the record
+-- Create enum type for SQL operations to reduce disk/memory usage vs text
+create type audit.operation as enum (
+    'INSERT',
+    'UPDATE',
+    'DELETE',
+    'TRUNCATE'
 );
-create index record_version_history_record_id on audit.record_version_history(record_id) where record_id is not null;
-create index record_version_history_old_record_id on audit.record_version_history(record_id) where old_record_id is not null;
+
+
+create table audit.record_version(
+    -- unique auto-incrementing id
+    id             bigserial primary key,
+    -- uniquely identifies a record by primary key [primary key + table_oid]
+    record_id      uuid,
+    -- uniquely identifies identity of record before update/delete before an update
+    old_record_id  uuid,
+    -- INSERT/UPDATE/DELETE/TRUNCATE/SNAPSHOT
+    op             audit.operation not null,
+    ts             timestamp not null default (now() at time zone 'utc'),
+    table_oid      int not null,
+    table_schema   name not null,
+    table_name     name not null,
+    -- contents of the record
+    record         json,
+
+    -- at least one of record_id and old_record id is populated, except for trucnates
+    check (coalesce(record_id, old_record_id) is not null or op = 'TRUNCATE'),
+
+    -- record_id must be populated for insert and update
+    check (op in ('INSERT', 'UPDATE') = (record_id is not null)),
+
+    -- old_record must be populated for update and delete
+    check (op in ('UPDATE', 'DELETE') = (old_record_id is not null))
+);
+
+
+create index record_version_record_id
+    on audit.record_version(record_id)
+    where record_id is not null;
+
+
+create index record_version_old_record_id
+    on audit.record_version(record_id)
+    where old_record_id is not null;
+
 
 create or replace function audit.primary_key_columns(entity_oid oid)
     returns text[]
@@ -51,6 +84,7 @@ as $$
         and indisprimary
 $$;
 
+
 create or replace function audit.to_record_id(entity_oid oid, pkey_cols text[], rec jsonb)
     returns uuid
     stable
@@ -59,77 +93,50 @@ as $$
     select
         uuid_generate_v5(
             'fd62bc3d-8d6e-43c2-919c-802ba3762271',
-            (select (jsonb_agg($3 ->> key_) || to_jsonb($1))::text from unnest($2) x(key_))
+            ( jsonb_build_array(to_jsonb($1)) || jsonb_agg($3 ->> key_) )::text
         )
+    from
+        unnest($2) x(key_)
 $$;
 
-create or replace function audit.change_trigger()
+
+create or replace function audit.insert_update_delete_trigger()
     returns trigger
     security definer
     language plpgsql
 as $$
+declare
+    pkey_cols text[] = audit.primary_key_columns(TG_RELID);
+    record_jsonb jsonb = to_jsonb(new);
+    old_record_jsonb jsonb = to_jsonb(old);
 begin
-    insert into audit.record_version_history(
+
+    insert into audit.record_version(
         record_id,
         old_record_id,
         op,
-        entity_oid,
+        table_oid,
+        table_schema,
+        table_name,
         record
     )
-    with pkey_cols as (
-        select
-            audit.primary_key_columns(TG_RELID) as column_names
-    )
     select
-        coalesce(ident.record_id, ident.old_record_id),
-        ident.old_record_id,
+        case
+            when new is null then null
+            when pkey_cols = array[]::text[] then null
+            else audit.to_record_id(TG_RELID, pkey_cols, record_jsonb)
+        end as record_id,
+        case
+            when old is null then null
+            when pkey_cols = array[]::text[] then null
+            else audit.to_record_id(TG_RELID, pkey_cols, old_record_jsonb)
+        end as old_record_id,
         TG_OP::audit.operation,
         TG_RELID,
-        rec.val
-    from
-        pkey_cols pk,
-        lateral (
-            -- new record as jsonb
-            select
-                to_jsonb(new) as val,
-                to_jsonb(old) as old_val
-        ) rec,
-        lateral (
-            select
-                case
-                    -- no primary key, use a UUID4
-                    when pk.column_names = array[]::text[] then null
-                    when new is null then null
-                    else audit.to_record_id(TG_RELID, pk.column_names, rec.val)
-                end as record_id,
-                case
-                    when old is null then null
-                    when pk.column_names = array[]::text[] then null
-                    else audit.to_record_id(TG_RELID, pk.column_names, rec.old_val)
-                end as old_record_id
-        ) ident;
-    return case TG_OP
-        when 'DELETE' then old
-        else new
-    end;
-end;
-$$;
+        TG_TABLE_SCHEMA,
+        TG_TABLE_NAME,
+        record_jsonb;
 
-create or replace function audit.get_version_history(record)
-    returns setof audit.record_version_history
-    stable
-    language plpgsql
-as $$
-declare
-    entity oid           = oid from pg_class where reltype = pg_typeof($1);
-    pk_cols text[]       = audit.primary_key_columns(entity);
-    input_record_id uuid = audit.to_record_id(entity, pk_cols, to_jsonb($1));
-begin
-    return query select
-        *
-    from
-        audit.record_version_history vh
-    where
-        record_id = input_record_id; -- indexed condition
+    return coalesce(old, new);
 end;
 $$;

--- a/test/expected/simple_insert_update_delete.out
+++ b/test/expected/simple_insert_update_delete.out
@@ -6,7 +6,7 @@ create trigger t
     before insert or update or delete
     on public.members
     for each row
-    execute procedure audit.change_trigger();
+    execute procedure audit.insert_update_delete_trigger();
 insert into public.members(id, name)
 values (1, 'foo');
 update public.members
@@ -18,14 +18,16 @@ select
     record_id,
     old_record_id,
     op,
-    entity_oid::regclass,
+    table_oid,
+    table_schema,
+    table_name,
     record
 from
-    audit.record_version_history;
- id |              record_id               |            old_record_id             |   op   | entity_oid |          record          
-----+--------------------------------------+--------------------------------------+--------+------------+--------------------------
-  1 | dd76759f-e596-510c-80a6-209bb6ee0d7d |                                      | INSERT | members    | {"id": 1, "name": "foo"}
-  2 | dd76759f-e596-510c-80a6-209bb6ee0d7d | dd76759f-e596-510c-80a6-209bb6ee0d7d | UPDATE | members    | {"id": 1, "name": "bar"}
-  3 | dd76759f-e596-510c-80a6-209bb6ee0d7d | dd76759f-e596-510c-80a6-209bb6ee0d7d | DELETE | members    | 
+    audit.record_version;
+ id |              record_id               |            old_record_id             |   op   | table_oid | table_schema | table_name |          record          
+----+--------------------------------------+--------------------------------------+--------+-----------+--------------+------------+--------------------------
+  1 | 12013ea2-4e1e-57c5-afd2-b77a3a573940 |                                      | INSERT |     16427 | public       | members    | {"id": 1, "name": "foo"}
+  2 | 12013ea2-4e1e-57c5-afd2-b77a3a573940 | 12013ea2-4e1e-57c5-afd2-b77a3a573940 | UPDATE |     16427 | public       | members    | {"id": 1, "name": "bar"}
+  3 |                                      | 12013ea2-4e1e-57c5-afd2-b77a3a573940 | DELETE |     16427 | public       | members    | 
 (3 rows)
 

--- a/test/sql/simple_insert_update_delete.sql
+++ b/test/sql/simple_insert_update_delete.sql
@@ -7,7 +7,7 @@ create trigger t
     before insert or update or delete
     on public.members
     for each row
-    execute procedure audit.change_trigger();
+    execute procedure audit.insert_update_delete_trigger();
 
 insert into public.members(id, name)
 values (1, 'foo');
@@ -23,7 +23,9 @@ select
     record_id,
     old_record_id,
     op,
-    entity_oid::regclass,
+    table_oid,
+    table_schema,
+    table_name,
     record
 from
-    audit.record_version_history;
+    audit.record_version;


### PR DESCRIPTION
## What kind of change does this PR introduce?
- converts primary trigger to plpgsql to improve readability
- `audit.record_version_history` -> `audit.record_version`
- track `table_name` and `table_schema` to support looking up table's identifiers if it has been dropped
- `audit.change_trigger` -> `audit.insert_update_delete_trigger`