### PR TITLE
Fix old_record_id index.

### DIFF
--- a/supa_audit--0.2.0.sql
+++ b/supa_audit--0.2.0.sql
@@ -91,7 +91,7 @@ create index record_version_record_id
 
 
 create index record_version_old_record_id
-    on audit.record_version(record_id)
+    on audit.record_version(old_record_id)
     where old_record_id is not null;
 
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Index is created on `record_id` column

## What is the new behavior?

Index should be created on `old_record_id` column

## Additional context

I believe it's a copy-paste error.
