### PR TITLE
Makefile: update data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 EXTENSION = supa_audit
-DATA = supa_audit--0.1.0.sql
-
-PG_CONFIG = pg_config
+DATA = $(wildcard *--*.sql)
 
 MODULE_big = supa_audit
 
@@ -9,5 +7,6 @@ TESTS = $(wildcard test/sql/*.sql)
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --use-existing --inputdir=test
 
+PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Current code doesn't include all data files

## What is the new behavior?

It includes all data files

## Additional context

`PGXS` fails either way on `make install`, I suppose because extension has no actual compiled code. I've tried fiddling with with other `ENV` vars, but with no success. Thanks!