### PR TITLE
feat(99ID): adjust record_id to use actual table's primary key

### DIFF
--- a/supa_audit--0.3.1.sql
+++ b/supa_audit--0.3.1.sql
@@ -143,13 +143,7 @@ as $$
             when rec is null then null
             when pkey_cols = array[]::text[] then uuid_generate_v4()
             else (
-                select
-                    uuid_generate_v5(
-                        'fd62bc3d-8d6e-43c2-919c-802ba3762271',
-                        ( jsonb_build_array(to_jsonb($1)) || jsonb_agg($3 ->> key_) )::text
-                    )
-                from
-                    unnest($2) x(key_)
+                (rec->>pkey_cols[1])::uuid
             )
         end
 $$;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

currently it generates uuidv5

## What is the new behavior?

, for 99ID case, we generate uuid per table

## Additional context

Add any other context or screenshots.
