### PR TITLE
Fix make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 EXTENSION = supa_audit
 DATA = $(wildcard *--*.sql)
 
-MODULE_big = supa_audit
-
 TESTS = $(wildcard test/sql/*.sql)
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --use-existing --inputdir=test


### PR DESCRIPTION
Fixes `make install` failing with `mkdir: missing operand`. Since
`MODULE_big` is set, PGXS expects to install a shared object/LLVM
bitcode files. Since this extension doesn't have any native code, remove
`MODULE_big`.

Curiously, a `.so` file seems to be built by PGXS despite no code being present.

```
/usr/bin/mkdir -p '…/usr/lib/postgresql'
/usr/bin/mkdir -p '…/usr/share/postgresql/extension'
/usr/bin/install -c -m 755  supa_audit.so '…/usr/lib/postgresql/supa_audit.so'
/usr/bin/mkdir -p '…/usr/share/postgresql/extension'
/usr/bin/install -c -m 644 .//supa_audit.control '…/usr/share/postgresql/extension/'
/usr/bin/install -c -m 644 .//supa_audit--0.1.0--0.2.0.sql .//supa_audit--0.2.0--0.2.1.sql .//supa_audit--0.2.1--0.2.2.sql .//supa_audit--0.2.2--0.2.3.sql .//supa_audit--0.2.3--0.3.0.sql .//supa_audit--0.3.0--0.3.1.sql .//supa_audit--0.3.1.sql  '…/usr/share/postgresql/extension/'
/usr/bin/mkdir -p '…/usr/lib/postgresql/bitcode/supa_audit'
/usr/bin/mkdir -p 
/usr/bin/mkdir: missing operand
Try '/usr/bin/mkdir --help' for more information.
make: *** [/usr/lib/postgresql/pgxs/src/makefiles/pgxs.mk:241: install] Error 1
```
