### PR TITLE
Create ensure-every-table-have-audit-enabled.sql

### DIFF
--- a/helpers/ensure-every-table-have-audit-enabled.sql
+++ b/helpers/ensure-every-table-have-audit-enabled.sql
@@ -1,0 +1,29 @@
+-- this script goes over tables in particular schema and attaches triggers for supabase audit
+-- comment 23 line if you want dry run
+
+DO $$
+DECLARE
+    t_table_name text;
+BEGIN
+    -- Loop through all tables in the 'public' schema
+    FOR t_table_name IN
+        SELECT table_name as t_table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+    LOOP
+        -- Check if the audit trigger exists for the current table
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_trigger
+            WHERE 
+                tgname LIKE 'audit_%'
+                AND tgrelid::regclass = format('public.%I', t_table_name)::regclass
+        ) THEN
+            RAISE NOTICE 'No audit triggers found for table: %', t_table_name;
+            PERFORM audit.enable_tracking(format('public.%I', t_table_name)::regclass);
+            RAISE NOTICE 'Audit triggers attached for table: %', t_table_name;
+        ELSE
+            RAISE NOTICE 'Audit triggers already exist for table: %', t_table_name;
+        END IF;
+    END LOOP;
+END $$;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: added script that will ensure that all tables have enabled audit triggers.

## What is the current behavior?

Users should enable audit for each table by hands, this can be tedious if done for systems with tens to hundreds of tables, especially with older/legacy systems.

## What is the new behavior?

This script simply traverse over all tables in given schema and applies audit triggers to them in case such triggers are not applied. The script may be executed in dry-run mode, please see comments in the file.

## Additional context

I would like to thank the authors and those who helped create supa_audit, you all did great job.
I also want to contribute to the development of this wonderful repo